### PR TITLE
Merge branch 'master' into resolved_warnings

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7984,15 +7984,11 @@ int pc_resetstate(struct map_session_data* sd)
 	}
 	else
 	{
-		int add=0;
-		add += pc_need_status_point(sd, SP_STR, 1-pc_getstat(sd, SP_STR));
-		add += pc_need_status_point(sd, SP_AGI, 1-pc_getstat(sd, SP_AGI));
-		add += pc_need_status_point(sd, SP_VIT, 1-pc_getstat(sd, SP_VIT));
-		add += pc_need_status_point(sd, SP_INT, 1-pc_getstat(sd, SP_INT));
-		add += pc_need_status_point(sd, SP_DEX, 1-pc_getstat(sd, SP_DEX));
-		add += pc_need_status_point(sd, SP_LUK, 1-pc_getstat(sd, SP_LUK));
+		sd->status.status_point = 48;
 
-		sd->status.status_point+=add;
+		for( int i = 1; i < sd->status.base_level; i++ ){
+			sd->status.status_point += pc_gets_status_point( i );
+		}
 	}
 
 	if( ( sd->class_&JOBL_UPPER ) != 0 ){


### PR DESCRIPTION
If use_statpoint_table was disabled and the player got additional stats or status points from somewhere (bugs in scripts, gm commands, etc.) they were not reset correctly, because the additional points were taken into account when reseting the stats.

Thanks to @Everade

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
